### PR TITLE
Nan.java: Add GPLv2+ header

### DIFF
--- a/Nan.java
+++ b/Nan.java
@@ -1,4 +1,19 @@
 // https://stackoverflow.com/questions/2618059/in-java-what-does-nan-mean/55673220#55673220
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 
 import java.lang.Float;
 import java.lang.Math;


### PR DESCRIPTION
Hello Ciro,
your repository is licensed under GPLv3 according to LICENSE.txt. As I want to include your Nan.java [as a testcase for OpenJDK](https://github.com/openjdk/jdk/pull/12508#discussion_r1118190852) and OpenJDK is GPLv2-only would it be possible to relicense your Nan.java as GPLv2+?
GPLv2+ would be still compatible with your repository GPLv3 and [it would be also compatible](https://opensource.stackexchange.com/a/7996/29495) with OpenJDK GPLv2-only.
The stackoverflow post is [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) which [is also incompatible](https://poststatus.com/the-creative-commons-license-is-now-compatible-with-the-gpl/) with GPLv2.

